### PR TITLE
FRA-4516: Surface manifest generator (M1 producer)

### DIFF
--- a/bin/generate-surface-manifest.php
+++ b/bin/generate-surface-manifest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Surface manifest generator — frame-php (producer for the conformance audit).
+ *
+ * Emits the SDK's public resource/method surface as JSON per the schema pinned
+ * in frame-docs CROSS_SDK_NAMING.md ("Surface-manifest schema (for the audit)"):
+ *
+ *   { "sdk", "version", "resources": { "<canonicalResource>": { "class",
+ *     "methods": [ { "name", "deprecated" } ] } } }
+ *
+ * FRA-4516 (producer half). Consumed by the conformance audit in the frame
+ * monolith (FRA-4457).
+ *
+ * Method surface = ReflectionClass over each Frame\Endpoints\* class: public
+ * instance methods declared on the endpoint class itself (no base class exists;
+ * constructors and inherited methods are excluded defensively).
+ *
+ * Deprecation = the `@deprecated` phpDoc tag on a method (none exist yet; the M2
+ * alias work adds them).
+ *
+ * Run: php bin/generate-surface-manifest.php [--out=PATH] [--stdout]
+ */
+
+$repoRoot = dirname(__DIR__);
+require $repoRoot . '/vendor/autoload.php';
+
+const SDK_NAME = 'frame-php';
+const ENDPOINTS_NAMESPACE = 'Frame\\Endpoints\\';
+const ENDPOINTS_DIR_REL = '/src/Endpoints';
+
+/*
+ * php endpoint class (short name) → canonical resource key, for the entries
+ * whose canonical name is not the naive lower-camelCase of the class. php
+ * classes are already PascalCase plural, so lcfirst() covers the majority.
+ * Deprecated resources (Customers, ChargeIntents) keep a legacy key so the
+ * audit can see and exclude them from the parity denominator.
+ */
+const CANONICAL_OVERRIDES = [
+    'ThreeDS' => 'threeDsIntents',
+    'IdentityVerifications' => 'customerIdentityVerifications',
+    'TermsOfService' => 'termsOfService',
+    'Customers' => 'customers',         // deprecated → accounts
+    'ChargeIntents' => 'chargeIntents', // deprecated → transfers
+];
+
+/** Methods that are never part of the public operation surface. */
+const NON_SURFACE_METHODS = ['__construct', '__destruct', '__call', '__callStatic', '__get', '__set'];
+
+/**
+ * Derive the canonical resource key from a php endpoint class short name.
+ * php class form is PascalCase plural (Transfers, PaymentMethods), so the
+ * canonical key is simply lcfirst(); irregulars live in CANONICAL_OVERRIDES.
+ */
+function canonicalResource(string $shortClass): string
+{
+    if (isset(CANONICAL_OVERRIDES[$shortClass])) {
+        return CANONICAL_OVERRIDES[$shortClass];
+    }
+
+    return lcfirst($shortClass);
+}
+
+/** Read the SDK version from the nearest git tag, falling back to 0.0.0-dev. */
+function readVersion(string $repoRoot): string
+{
+    $tag = @exec('git -C ' . escapeshellarg($repoRoot) . ' describe --tags --abbrev=0 2>/dev/null');
+    if (is_string($tag) && $tag !== '') {
+        return ltrim($tag, 'v');
+    }
+
+    return '0.0.0-dev';
+}
+
+/** @return list<class-string> fully-qualified endpoint class names */
+function discoverEndpointClasses(string $repoRoot): array
+{
+    $dir = $repoRoot . ENDPOINTS_DIR_REL;
+    $classes = [];
+    foreach (scandir($dir) ?: [] as $file) {
+        if (!str_ends_with($file, '.php')) {
+            continue;
+        }
+        $short = substr($file, 0, -4);
+        $fqcn = ENDPOINTS_NAMESPACE . $short;
+        if (class_exists($fqcn)) {
+            $classes[] = $fqcn;
+        }
+    }
+    sort($classes);
+
+    return $classes;
+}
+
+function isDeprecated(ReflectionMethod $method): bool
+{
+    $doc = $method->getDocComment();
+
+    return $doc !== false && preg_match('/@deprecated\b/', $doc) === 1;
+}
+
+/**
+ * @return list<array{name: string, deprecated: bool}>
+ */
+function surfaceMethods(ReflectionClass $class): array
+{
+    $methods = [];
+    foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+        // Only methods declared on the endpoint class itself, instance-level,
+        // and not magic/plumbing.
+        if ($method->getDeclaringClass()->getName() !== $class->getName()) {
+            continue;
+        }
+        if ($method->isStatic()) {
+            continue;
+        }
+        if (in_array($method->getName(), NON_SURFACE_METHODS, true)) {
+            continue;
+        }
+        $methods[] = [
+            'name' => $method->getName(),
+            'deprecated' => isDeprecated($method),
+        ];
+    }
+
+    usort($methods, static fn ($a, $b) => strcmp($a['name'], $b['name']));
+
+    return $methods;
+}
+
+function buildManifest(string $repoRoot): array
+{
+    $resources = [];
+    foreach (discoverEndpointClasses($repoRoot) as $fqcn) {
+        $class = new ReflectionClass($fqcn);
+        $short = $class->getShortName();
+        $resources[canonicalResource($short)] = [
+            'class' => $short,
+            'methods' => surfaceMethods($class),
+        ];
+    }
+    ksort($resources);
+
+    return [
+        'sdk' => SDK_NAME,
+        'version' => readVersion($repoRoot),
+        'resources' => $resources,
+    ];
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+$toStdout = false;
+$outPath = $repoRoot . '/surface-manifest.json';
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg === '--stdout') {
+        $toStdout = true;
+    } elseif (str_starts_with($arg, '--out=')) {
+        $outPath = substr($arg, strlen('--out='));
+    }
+}
+
+$manifest = buildManifest($repoRoot);
+$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+
+if ($toStdout) {
+    fwrite(STDOUT, $json);
+} else {
+    file_put_contents($outPath, $json);
+    $methodCount = array_sum(array_map(static fn ($r) => count($r['methods']), $manifest['resources']));
+    fwrite(STDERR, sprintf(
+        "Wrote %s: %d resources, %d methods (v%s)\n",
+        $outPath,
+        count($manifest['resources']),
+        $methodCount,
+        $manifest['version'],
+    ));
+}

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "scripts": {
       "test": "phpunit",
-      "test-coverage": "phpunit --coverage-html coverage"
+      "test-coverage": "phpunit --coverage-html coverage",
+      "surface-manifest": "php bin/generate-surface-manifest.php"
     },
     "config": {
         "allow-plugins": {

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,0 +1,760 @@
+{
+    "sdk": "frame-php",
+    "version": "1.0.11",
+    "resources": {
+        "accounts": {
+            "class": "Accounts",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "disable",
+                    "deprecated": false
+                },
+                {
+                    "name": "geoCompliance",
+                    "deprecated": false
+                },
+                {
+                    "name": "getPaymentMethods",
+                    "deprecated": false
+                },
+                {
+                    "name": "getPlaidLinkToken",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "restrict",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "search",
+                    "deprecated": false
+                },
+                {
+                    "name": "unrestrict",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "billing": {
+            "class": "Billing",
+            "methods": [
+                {
+                    "name": "createBillingCredit",
+                    "deprecated": false
+                },
+                {
+                    "name": "createBillingInvoice",
+                    "deprecated": false
+                },
+                {
+                    "name": "createMetering",
+                    "deprecated": false
+                },
+                {
+                    "name": "createMeteringEvent",
+                    "deprecated": false
+                },
+                {
+                    "name": "getBillingCredit",
+                    "deprecated": false
+                },
+                {
+                    "name": "getCustomerReport",
+                    "deprecated": false
+                },
+                {
+                    "name": "getEventReport",
+                    "deprecated": false
+                },
+                {
+                    "name": "getEventsReport",
+                    "deprecated": false
+                },
+                {
+                    "name": "getMetering",
+                    "deprecated": false
+                },
+                {
+                    "name": "getMeteringEvent",
+                    "deprecated": false
+                },
+                {
+                    "name": "getSubscriptionReport",
+                    "deprecated": false
+                },
+                {
+                    "name": "updateMetering",
+                    "deprecated": false
+                },
+                {
+                    "name": "updateMeteringEvent",
+                    "deprecated": false
+                }
+            ]
+        },
+        "capabilities": {
+            "class": "Capabilities",
+            "methods": [
+                {
+                    "name": "disable",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "request",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
+        "chargeIntents": {
+            "class": "ChargeIntents",
+            "methods": [
+                {
+                    "name": "cancel",
+                    "deprecated": false
+                },
+                {
+                    "name": "capture",
+                    "deprecated": false
+                },
+                {
+                    "name": "confirm",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                },
+                {
+                    "name": "voidRemaining",
+                    "deprecated": false
+                }
+            ]
+        },
+        "chargeSessions": {
+            "class": "ChargeSessions",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "charges": {
+            "class": "Charges",
+            "methods": [
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "trace",
+                    "deprecated": false
+                }
+            ]
+        },
+        "coupons": {
+            "class": "Coupons",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "customerIdentityVerifications": {
+            "class": "IdentityVerifications",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "uploadDocuments",
+                    "deprecated": false
+                }
+            ]
+        },
+        "customers": {
+            "class": "Customers",
+            "methods": [
+                {
+                    "name": "block",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "getPaymentMethods",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "search",
+                    "deprecated": false
+                },
+                {
+                    "name": "unblock",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "discounts": {
+            "class": "Discounts",
+            "methods": [
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "validate",
+                    "deprecated": false
+                }
+            ]
+        },
+        "disputes": {
+            "class": "Disputes",
+            "methods": [
+                {
+                    "name": "createDocument",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "geofences": {
+            "class": "Geofences",
+            "methods": [
+                {
+                    "name": "list",
+                    "deprecated": false
+                }
+            ]
+        },
+        "invoiceLineItems": {
+            "class": "InvoiceLineItems",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "invoices": {
+            "class": "Invoices",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "issue",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "onboarding": {
+            "class": "Onboarding",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "payout",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "onboardingSessions": {
+            "class": "OnboardingSessions",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                }
+            ]
+        },
+        "paymentLinkSessions": {
+            "class": "PaymentLinkSessions",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                }
+            ]
+        },
+        "paymentMethods": {
+            "class": "PaymentMethods",
+            "methods": [
+                {
+                    "name": "attach",
+                    "deprecated": false
+                },
+                {
+                    "name": "block",
+                    "deprecated": false
+                },
+                {
+                    "name": "createBank",
+                    "deprecated": false
+                },
+                {
+                    "name": "createCard",
+                    "deprecated": false
+                },
+                {
+                    "name": "detach",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieveForCustomer",
+                    "deprecated": false
+                },
+                {
+                    "name": "unblock",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "payouts": {
+            "class": "Payouts",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                }
+            ]
+        },
+        "phoneVerifications": {
+            "class": "PhoneVerifications",
+            "methods": [
+                {
+                    "name": "confirm",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                }
+            ]
+        },
+        "productPhases": {
+            "class": "ProductPhases",
+            "methods": [
+                {
+                    "name": "bulkUpdate",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "products": {
+            "class": "Products",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "search",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "promotionCodes": {
+            "class": "PromotionCodes",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "refunds": {
+            "class": "Refunds",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
+        "sonarSessions": {
+            "class": "SonarSessions",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "subscriptionChangeLogs": {
+            "class": "SubscriptionChangeLogs",
+            "methods": [
+                {
+                    "name": "list",
+                    "deprecated": false
+                }
+            ]
+        },
+        "subscriptionPhases": {
+            "class": "SubscriptionPhases",
+            "methods": [
+                {
+                    "name": "bulkUpdate",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "subscriptions": {
+            "class": "Subscriptions",
+            "methods": [
+                {
+                    "name": "cancel",
+                    "deprecated": false
+                },
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "search",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "termsOfService": {
+            "class": "TermsOfService",
+            "methods": [
+                {
+                    "name": "createToken",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "threeDsIntents": {
+            "class": "ThreeDS",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "resend",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
+        "transferBillingAgreements": {
+            "class": "TransferBillingAgreements",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
+                    "deprecated": false
+                }
+            ]
+        },
+        "transferFeePlans": {
+            "class": "TransferFeePlans",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
+        "transfers": {
+            "class": "Transfers",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
+        "webhookEndpoints": {
+            "class": "WebhookEndpoints",
+            "methods": [
+                {
+                    "name": "list",
+                    "deprecated": false
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## FRA-4516 — Surface manifest generator (M1 producer)

Adds the **producer half** of the cross-SDK conformance audit. This SDK now emits a `surface-manifest.json` describing its public resource/method surface, to the schema pinned in [`CROSS_SDK_NAMING.md`](https://github.com/Frame-Payments/frame-docs/blob/main/lib/sdk-docs-standards/CROSS_SDK_NAMING.md). The audit (FRA-4457, in the monolith) consumes all three SDKs' manifests and asserts every canonical non-deprecated op resolves in each SDK or is on the exclusion list.

### What's here
- `bin/generate-surface-manifest.php` — the generator
- `surface-manifest.json` — generated output (committed; sorted + idempotent so CI can diff it)
- `composer.json` — adds `composer surface-manifest`

### How it works
- **Runtime reflection** via `ReflectionClass` over each `Frame\Endpoints\*` class: public instance methods declared on the endpoint class itself. Excludes magic methods and anything inherited.
- **Canonical resource keys**: class names are mapped to canonical (`ThreeDS` → `threeDsIntents`, `IdentityVerifications` → `customerIdentityVerifications`). Deprecated resources (`customers`, `chargeIntents`) are retained under legacy keys so the audit can see and exclude them from the parity denominator.
- **Deprecation**: reads the `@deprecated` phpDoc tag to set `deprecated` per method. None exist yet — flips on when M2 adds aliases.
- **Version**: read from the nearest git tag (composer libs carry no `version` field).

### Output shape
```json
{ "sdk": "frame-php", "version": "1.0.11",
  "resources": { "transfers": { "class": "Transfers",
    "methods": [ { "name": "create", "deprecated": false } ] } } }
```
34 resources / 146 methods. Surfaces the expected gap: `webhookEndpoints` is `list`-only today (M0 "surface to build": add create/retrieve/update/delete/rotateSecret).

### Notes for the audit consumer (@ryan)
- `methods[].name` is the SDK's **native** identifier — the audit canonicalizes via the FRA-4456 caser. Deliberately not pre-canonicalized.
- Please confirm the interface before FRA-4457 lands. See the FRA-4516 comment for full producer-side decisions.

### Testing
Generator is idempotent (byte-identical on re-run).

Linear: FRA-4516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
