### PR TITLE
FRA-4471: Identity/onboarding/3DS + singletons parity

### DIFF
--- a/src/Endpoints/CustomerIdentityVerifications.php
+++ b/src/Endpoints/CustomerIdentityVerifications.php
@@ -28,10 +28,12 @@ class CustomerIdentityVerifications
      * Create an identity verification for an existing customer.
      * POST /v1/customer_identity_verifications/{customer_id}
      * (monolith customer_identity_verifications#create_from_customer).
+     * The documented route takes only the customer_id path param — no request
+     * body — so no params argument is exposed.
      */
-    public function createForCustomer(string $customerId, array $params = []): CustomerIdentity
+    public function createForCustomer(string $customerId): CustomerIdentity
     {
-        $json = Client::post(self::BASE_PATH . "/{$customerId}", $params);
+        $json = Client::post(self::BASE_PATH . "/{$customerId}");
 
         return CustomerIdentity::fromArray($json);
     }

--- a/src/Endpoints/CustomerIdentityVerifications.php
+++ b/src/Endpoints/CustomerIdentityVerifications.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Endpoints;
+
+use Frame\Client;
+use Frame\Models\IdentityVerifications\CustomerIdentity;
+use Frame\Models\IdentityVerifications\IdentityCreateRequest;
+
+/**
+ * Canonical customer identity verifications endpoint (resource
+ * `customerIdentityVerifications`, per CROSS_SDK_NAMING.md). The legacy
+ * `IdentityVerifications` class is retained as a deprecated subclass alias.
+ */
+class CustomerIdentityVerifications
+{
+    private const BASE_PATH = '/v1/customer_identity_verifications';
+
+    public function create(IdentityCreateRequest $params): CustomerIdentity
+    {
+        $json = Client::post(self::BASE_PATH, $params->toArray());
+
+        return CustomerIdentity::fromArray($json);
+    }
+
+    /**
+     * Create an identity verification for an existing customer.
+     * POST /v1/customer_identity_verifications/{customer_id}
+     * (monolith customer_identity_verifications#create_from_customer).
+     */
+    public function createForCustomer(string $customerId, array $params = []): CustomerIdentity
+    {
+        $json = Client::post(self::BASE_PATH . "/{$customerId}", $params);
+
+        return CustomerIdentity::fromArray($json);
+    }
+
+    public function retrieve(string $id): CustomerIdentity
+    {
+        $json = Client::get(self::BASE_PATH . "/{$id}");
+
+        return CustomerIdentity::fromArray($json);
+    }
+
+    public function uploadDocuments(string $id, array $params): array
+    {
+        return Client::post(self::BASE_PATH . "/{$id}/upload_documents", $params);
+    }
+}

--- a/src/Endpoints/IdentityVerifications.php
+++ b/src/Endpoints/IdentityVerifications.php
@@ -4,30 +4,35 @@ declare(strict_types=1);
 
 namespace Frame\Endpoints;
 
-use Frame\Client;
 use Frame\Models\IdentityVerifications\CustomerIdentity;
 use Frame\Models\IdentityVerifications\IdentityCreateRequest;
 
-final class IdentityVerifications
+/**
+ * @deprecated Use {@see CustomerIdentityVerifications} (canonical resource
+ *   `customerIdentityVerifications`). Retained as a thin alias for backward
+ *   compatibility; removed at v2. Methods forward to the canonical class; they
+ *   are re-declared (rather than purely inherited) so the surface manifest
+ *   reflects the same operation set under either class name.
+ */
+final class IdentityVerifications extends CustomerIdentityVerifications
 {
-    private const BASE_PATH = '/v1/customer_identity_verifications';
-
     public function create(IdentityCreateRequest $params): CustomerIdentity
     {
-        $json = Client::post(self::BASE_PATH, $params->toArray());
+        return parent::create($params);
+    }
 
-        return CustomerIdentity::fromArray($json);
+    public function createForCustomer(string $customerId, array $params = []): CustomerIdentity
+    {
+        return parent::createForCustomer($customerId, $params);
     }
 
     public function retrieve(string $id): CustomerIdentity
     {
-        $json = Client::get(self::BASE_PATH . "/{$id}");
-
-        return CustomerIdentity::fromArray($json);
+        return parent::retrieve($id);
     }
 
     public function uploadDocuments(string $id, array $params): array
     {
-        return Client::post('/v1/customer_identity_verifications' . "/{$id}/upload_documents", $params);
+        return parent::uploadDocuments($id, $params);
     }
 }

--- a/src/Endpoints/IdentityVerifications.php
+++ b/src/Endpoints/IdentityVerifications.php
@@ -21,9 +21,9 @@ final class IdentityVerifications extends CustomerIdentityVerifications
         return parent::create($params);
     }
 
-    public function createForCustomer(string $customerId, array $params = []): CustomerIdentity
+    public function createForCustomer(string $customerId): CustomerIdentity
     {
-        return parent::createForCustomer($customerId, $params);
+        return parent::createForCustomer($customerId);
     }
 
     public function retrieve(string $id): CustomerIdentity

--- a/src/Endpoints/MerchantBalance.php
+++ b/src/Endpoints/MerchantBalance.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Endpoints;
+
+use Frame\Client;
+
+/**
+ * Top-level singleton: the authenticated merchant's balance (available funds,
+ * reserved amounts, pending payouts). GET /v1/merchant_balance — no id.
+ */
+final class MerchantBalance
+{
+    private const BASE_PATH = '/v1/merchant_balance';
+
+    public function retrieve(): array
+    {
+        return Client::get(self::BASE_PATH);
+    }
+}

--- a/src/Endpoints/OnboardingSessions.php
+++ b/src/Endpoints/OnboardingSessions.php
@@ -26,4 +26,16 @@ final class OnboardingSessions
 
         return OnboardingSessionListResponse::fromArray($json);
     }
+
+    /**
+     * Bootstrap the embedded onboarding Web Component from a client_secret.
+     * GET /v1/onboarding_sessions/bootstrap — authenticate with the onb_sess_*
+     * token. Returns session metadata, the ordered step list, and full account
+     * context in one payload (returned raw; the account block does not map to
+     * the OnboardingSession model).
+     */
+    public function bootstrap(): array
+    {
+        return Client::get(self::BASE_PATH . '/bootstrap');
+    }
 }

--- a/src/Endpoints/ThreeDS.php
+++ b/src/Endpoints/ThreeDS.php
@@ -4,24 +4,27 @@ declare(strict_types=1);
 
 namespace Frame\Endpoints;
 
-use Frame\Client;
-
-final class ThreeDS
+/**
+ * @deprecated Use {@see ThreeDsIntents} (canonical resource `threeDsIntents`).
+ *   Retained as a thin alias for backward compatibility; removed at v2. Methods
+ *   forward to the canonical class; they are re-declared (rather than purely
+ *   inherited) so the surface manifest reflects the same operation set under
+ *   either class name.
+ */
+final class ThreeDS extends ThreeDsIntents
 {
-    private const BASE_PATH = '/v1/3ds/intents';
-
     public function create(array $params): array
     {
-        return Client::post(self::BASE_PATH, $params);
+        return parent::create($params);
     }
 
     public function retrieve(string $id): array
     {
-        return Client::get(self::BASE_PATH . "/{$id}");
+        return parent::retrieve($id);
     }
 
     public function resend(string $id): array
     {
-        return Client::post(self::BASE_PATH . "/{$id}/resend", []);
+        return parent::resend($id);
     }
 }

--- a/src/Endpoints/ThreeDsIntents.php
+++ b/src/Endpoints/ThreeDsIntents.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Endpoints;
+
+use Frame\Client;
+
+/**
+ * Canonical 3DS intents endpoint (resource `threeDsIntents`, per
+ * CROSS_SDK_NAMING.md — `DS` is in the acronym registry). The legacy `ThreeDS`
+ * class is retained as a deprecated subclass alias for backward compatibility.
+ */
+class ThreeDsIntents
+{
+    private const BASE_PATH = '/v1/3ds/intents';
+
+    public function create(array $params): array
+    {
+        return Client::post(self::BASE_PATH, $params);
+    }
+
+    public function retrieve(string $id): array
+    {
+        return Client::get(self::BASE_PATH . "/{$id}");
+    }
+
+    public function resend(string $id): array
+    {
+        return Client::post(self::BASE_PATH . "/{$id}/resend", []);
+    }
+}

--- a/tests/Endpoints/CustomerIdentityVerificationsTest.php
+++ b/tests/Endpoints/CustomerIdentityVerificationsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\CustomerIdentityVerifications;
+use Frame\Models\Customers\Address;
+use Frame\Models\IdentityVerifications\CustomerIdentity;
+use Frame\Models\IdentityVerifications\IdentityCreateRequest;
+use Frame\Tests\TestCase;
+use Mockery;
+
+/**
+ * Direct coverage of the canonical CustomerIdentityVerifications class. The
+ * legacy IdentityVerifications subclass is covered separately in
+ * IdentityVerificationsTest; this asserts the canonical class's routes on its
+ * own so they can't regress independently of the deprecated alias.
+ */
+class CustomerIdentityVerificationsTest extends TestCase
+{
+    private $endpoint;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->endpoint = new CustomerIdentityVerifications();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testCreate()
+    {
+        $address = Address::fromArray($this->getSampleAddressData());
+        $createRequest = new IdentityCreateRequest(firstName: 'John', lastName: 'Doe', dateOfBirth: 'XX-XX-XXXX', email: 'johndoe@frame.com', phoneNumber: '1111111111', ssn: 'XXX-XX-XXXX', address: $address);
+        $sample = $this->getSampleCustomerIdentityData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/customer_identity_verifications', $createRequest->toArray())
+            ->andReturn($sample);
+
+        $result = $this->endpoint->create($createRequest);
+        $this->assertInstanceOf(CustomerIdentity::class, $result);
+        $this->assertEquals($sample['id'], $result->id);
+    }
+
+    public function testCreateForCustomer()
+    {
+        $customerId = 'cus_123';
+        $sample = $this->getSampleCustomerIdentityData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/customer_identity_verifications/{$customerId}")
+            ->andReturn($sample);
+
+        $result = $this->endpoint->createForCustomer($customerId);
+        $this->assertInstanceOf(CustomerIdentity::class, $result);
+        $this->assertEquals($sample['id'], $result->id);
+    }
+
+    public function testRetrieve()
+    {
+        $id = 'cusIdentity_123';
+        $sample = $this->getSampleCustomerIdentityData();
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with("/v1/customer_identity_verifications/{$id}")
+            ->andReturn($sample);
+
+        $result = $this->endpoint->retrieve($id);
+        $this->assertInstanceOf(CustomerIdentity::class, $result);
+        $this->assertEquals($sample['id'], $result->id);
+    }
+}

--- a/tests/Endpoints/IdentityVerificationsTest.php
+++ b/tests/Endpoints/IdentityVerificationsTest.php
@@ -63,4 +63,29 @@ class IdentityVerificationsTest extends TestCase
         $this->assertInstanceOf(CustomerIdentity::class, $customerIdentity);
         $this->assertEquals($sampleIdentityData['id'], $customerIdentity->id);
     }
+
+    public function testCreateForCustomer()
+    {
+        $customerId = 'cus_123';
+        $sampleIdentityData = $this->getSampleCustomerIdentityData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/customer_identity_verifications/{$customerId}", [])
+            ->andReturn($sampleIdentityData);
+
+        $customerIdentity = $this->identityVerificationEndpoint->createForCustomer($customerId);
+
+        $this->assertInstanceOf(CustomerIdentity::class, $customerIdentity);
+        $this->assertEquals($sampleIdentityData['id'], $customerIdentity->id);
+    }
+
+    public function testLegacyClassIsDeprecatedAliasOfCanonical()
+    {
+        $this->assertInstanceOf(
+            \Frame\Endpoints\CustomerIdentityVerifications::class,
+            new IdentityVerifications(),
+        );
+    }
 }

--- a/tests/Endpoints/IdentityVerificationsTest.php
+++ b/tests/Endpoints/IdentityVerificationsTest.php
@@ -72,7 +72,7 @@ class IdentityVerificationsTest extends TestCase
         $this->mockClient
             ->shouldReceive('post')
             ->once()
-            ->with("/v1/customer_identity_verifications/{$customerId}", [])
+            ->with("/v1/customer_identity_verifications/{$customerId}")
             ->andReturn($sampleIdentityData);
 
         $customerIdentity = $this->identityVerificationEndpoint->createForCustomer($customerId);
@@ -87,5 +87,28 @@ class IdentityVerificationsTest extends TestCase
             \Frame\Endpoints\CustomerIdentityVerifications::class,
             new IdentityVerifications(),
         );
+    }
+
+    /**
+     * The deprecated subclass must RE-DECLARE each operation (as a parent::
+     * forwarder), not merely inherit it — the surface-manifest generator only
+     * reflects methods declared on the class, and the deprecated + canonical
+     * classes map to the same manifest key. If the forwarders were deleted in
+     * favor of pure inheritance, the deprecated class would overwrite the
+     * canonical manifest entry with an empty method list. This asserts the
+     * invariant so that regression can't land silently.
+     *
+     * @dataProvider forwardedMethods
+     */
+    public function testDeprecatedSubclassDeclaresItsOwnMethods(string $method)
+    {
+        $declaring = (new \ReflectionMethod(IdentityVerifications::class, $method))
+            ->getDeclaringClass()->getName();
+        $this->assertEquals(IdentityVerifications::class, $declaring);
+    }
+
+    public static function forwardedMethods(): array
+    {
+        return [['create'], ['createForCustomer'], ['retrieve'], ['uploadDocuments']];
     }
 }

--- a/tests/Endpoints/MerchantBalanceTest.php
+++ b/tests/Endpoints/MerchantBalanceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\MerchantBalance;
+use Frame\Tests\TestCase;
+use Mockery;
+
+class MerchantBalanceTest extends TestCase
+{
+    private $merchantBalance;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->merchantBalance = new MerchantBalance();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testRetrieve()
+    {
+        $sample = [
+            'merchant_id' => 'mer_123',
+            'currency' => 'USD',
+            'available_for_payout' => 40000.0,
+            'status' => 'AVAILABLE',
+        ];
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with('/v1/merchant_balance')
+            ->andReturn($sample);
+
+        $balance = $this->merchantBalance->retrieve();
+
+        $this->assertEquals('USD', $balance['currency']);
+        $this->assertEquals('AVAILABLE', $balance['status']);
+    }
+}

--- a/tests/Endpoints/OnboardingSessionsTest.php
+++ b/tests/Endpoints/OnboardingSessionsTest.php
@@ -71,4 +71,21 @@ class OnboardingSessionsTest extends TestCase
         $this->assertCount(1, $response->sessions);
         $this->assertEquals($sampleListData['data'][0]['id'], $response->sessions[0]->id);
     }
+
+    public function testBootstrap()
+    {
+        $sample = $this->getSampleAccountOnboardingSessionData() + [
+            'account' => ['id' => 'acct_test123', 'status' => 'active'],
+        ];
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with('/v1/onboarding_sessions/bootstrap')
+            ->andReturn($sample);
+
+        $response = $this->onboardingSessionsEndpoint->bootstrap();
+
+        $this->assertEquals('acct_test123', $response['account']['id']);
+    }
 }

--- a/tests/Endpoints/ThreeDsIntentsTest.php
+++ b/tests/Endpoints/ThreeDsIntentsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\ThreeDS;
+use Frame\Endpoints\ThreeDsIntents;
+use Frame\Tests\TestCase;
+use Mockery;
+
+class ThreeDsIntentsTest extends TestCase
+{
+    private $threeDsIntents;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->threeDsIntents = new ThreeDsIntents();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testCreate()
+    {
+        $sample = ['id' => '3ds_123', 'object' => 'three_ds_intent', 'status' => 'pending'];
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/3ds/intents', [])
+            ->andReturn($sample);
+
+        $this->assertEquals($sample, $this->threeDsIntents->create([]));
+    }
+
+    public function testRetrieve()
+    {
+        $sample = ['id' => '3ds_123', 'object' => 'three_ds_intent'];
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with('/v1/3ds/intents/3ds_123')
+            ->andReturn($sample);
+
+        $this->assertEquals($sample, $this->threeDsIntents->retrieve('3ds_123'));
+    }
+
+    public function testResend()
+    {
+        $sample = ['id' => '3ds_123', 'object' => 'three_ds_intent'];
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/3ds/intents/3ds_123/resend', [])
+            ->andReturn($sample);
+
+        $this->assertEquals($sample, $this->threeDsIntents->resend('3ds_123'));
+    }
+
+    public function testLegacyClassIsDeprecatedAliasOfCanonical()
+    {
+        $this->assertInstanceOf(ThreeDsIntents::class, new ThreeDS());
+    }
+}

--- a/tests/Endpoints/ThreeDsIntentsTest.php
+++ b/tests/Endpoints/ThreeDsIntentsTest.php
@@ -69,4 +69,24 @@ class ThreeDsIntentsTest extends TestCase
     {
         $this->assertInstanceOf(ThreeDsIntents::class, new ThreeDS());
     }
+
+    /**
+     * The deprecated ThreeDS subclass must re-declare each operation (parent::
+     * forwarder), not merely inherit it, so the surface manifest reports the op
+     * set under the deprecated key too. See the equivalent note in
+     * IdentityVerificationsTest.
+     *
+     * @dataProvider forwardedMethods
+     */
+    public function testDeprecatedSubclassDeclaresItsOwnMethods(string $method)
+    {
+        $declaring = (new \ReflectionMethod(ThreeDS::class, $method))
+            ->getDeclaringClass()->getName();
+        $this->assertEquals(ThreeDS::class, $declaring);
+    }
+
+    public static function forwardedMethods(): array
+    {
+        return [['create'], ['retrieve'], ['resend']];
+    }
 }


### PR DESCRIPTION
## FRA-4471 — Identity / onboarding / 3DS + singletons parity

M2 vertical slice. Brings the identity/onboarding/3DS resource group to canonical parity and adds the net-new singletons — **additively** (`@deprecated` aliases, nothing removed). Built against the public OpenAPI spec + monolith routes.

### Net-new surface (all 3 SDKs)
- **`merchantBalance.retrieve`** → `GET /v1/merchant_balance` (new top-level singleton, no id).
- **`onboardingSessions.bootstrap`** → `GET /v1/onboarding_sessions/bootstrap` (note: a GET despite the name; auth with the `onb_sess_*` token).

### Naming convergence (additive)
- **3DS base → canonical `threeDsIntents`** (`DS` is in the acronym registry). Legacy `threeDS` / `ThreeDS` / `ThreeDSAPI` retained as `@deprecated` aliases pointing at the same surface.
- **node `get` → `retrieve`** on customerIdentityVerifications and threeDsIntents (`get` kept as `@deprecated`).
- **`onboardingSessions.getByAccount` → `list`** (node); `getByAccount` kept as `@deprecated`.

### Bugfix rolled in
- **`createForCustomer` corrected to the documented route** `POST /v1/customer_identity_verifications/{customer_id}` (the monolith `create_from_customer` action). node was posting to `/v1/customers/{id}/identity_verifications`, which has **no backing route**. Added `createForCustomer` to ruby/php on the correct path for parity.

### ⚠️ Spec discrepancy flagged (not built)
The ticket lists `customerIdentityVerifications.list` as canonical, but **no list/index endpoint exists** — the monolith exposes this resource as `only: [:create, :show]` and the public spec has no GET on the collection. So `list` was **not** added to node/php. ruby already had a `list` method calling that non-existent route (dead code that 404s); it's marked `@deprecated` here (removed at v2), not extended. Recommend correcting the ticket's canonical target.

### Tests
Full coverage added per SDK; all suites green:
- node: 186 tests, typecheck clean
- ruby: 176 tests, standardrb clean
- php: 123 tests, phpstan + cs-fixer clean

Surface manifests (FRA-4516) regenerate to the canonical set across all three; cross-SDK parity verified for merchantBalance / onboardingSessions.bootstrap / threeDsIntents / createForCustomer.

Note: `surface-manifest.json` is intentionally not included here — it's the FRA-4516 artifact and regenerates once that lands.

Linear: FRA-4471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
