### PR TITLE
feat: converge php onto the canonical surface + fix generator class collision [FRA-5269]

### DIFF
--- a/bin/generate-surface-manifest.php
+++ b/bin/generate-surface-manifest.php
@@ -101,6 +101,13 @@ function isDeprecated(ReflectionMethod $method): bool
     return $doc !== false && preg_match('/@deprecated\b/', $doc) === 1;
 }
 
+function classIsDeprecated(ReflectionClass $class): bool
+{
+    $doc = $class->getDocComment();
+
+    return $doc !== false && preg_match('/@deprecated\b/', $doc) === 1;
+}
+
 /**
  * @return list<array{name: string, deprecated: bool}>
  */
@@ -136,7 +143,17 @@ function buildManifest(string $repoRoot): array
     foreach (discoverEndpointClasses($repoRoot) as $fqcn) {
         $class = new ReflectionClass($fqcn);
         $short = $class->getShortName();
-        $resources[canonicalResource($short)] = [
+        $key = canonicalResource($short);
+
+        // A canonical class and its deprecated backward-compat alias subclass
+        // (e.g. IdentityVerifications extends CustomerIdentityVerifications) map
+        // to the same canonical key. Keep the canonical class; a deprecated alias
+        // must never overwrite it (order-independent: canonical wins either way).
+        if (isset($resources[$key]) && classIsDeprecated($class)) {
+            continue;
+        }
+
+        $resources[$key] = [
             'class' => $short,
             'methods' => surfaceMethods($class),
         ];

--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -83,8 +83,16 @@ final class Accounts
         return PaymentMethodListResponse::fromArray($json);
     }
 
-    public function geoCompliance(string $id): array
+    public function getGeoCompliance(string $id): array
     {
         return Client::get(self::BASE_PATH . "/{$id}/geo_compliance");
+    }
+
+    /**
+     * @deprecated Use {@see getGeoCompliance()} (canonical). Removed at v2.
+     */
+    public function geoCompliance(string $id): array
+    {
+        return $this->getGeoCompliance($id);
     }
 }

--- a/src/Endpoints/PaymentMethods.php
+++ b/src/Endpoints/PaymentMethods.php
@@ -22,11 +22,19 @@ final class PaymentMethods
         return PaymentMethod::fromArray($json);
     }
 
-    public function createBank(PaymentMethodCreateACHRequest $params): PaymentMethod
+    public function createBankAccount(PaymentMethodCreateACHRequest $params): PaymentMethod
     {
         $json = Client::post(self::BASE_PATH, $params->toArray());
 
         return PaymentMethod::fromArray($json);
+    }
+
+    /**
+     * @deprecated Use {@see createBankAccount()} (canonical). Removed at v2.
+     */
+    public function createBank(PaymentMethodCreateACHRequest $params): PaymentMethod
+    {
+        return $this->createBankAccount($params);
     }
 
     public function update(string $id, PaymentMethodUpdateRequest $params): PaymentMethod

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -15,6 +15,10 @@
                 },
                 {
                     "name": "geoCompliance",
+                    "deprecated": true
+                },
+                {
+                    "name": "getGeoCompliance",
                     "deprecated": false
                 },
                 {
@@ -214,10 +218,14 @@
             ]
         },
         "customerIdentityVerifications": {
-            "class": "IdentityVerifications",
+            "class": "CustomerIdentityVerifications",
             "methods": [
                 {
                     "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "createForCustomer",
                     "deprecated": false
                 },
                 {
@@ -372,6 +380,15 @@
                 }
             ]
         },
+        "merchantBalance": {
+            "class": "MerchantBalance",
+            "methods": [
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
         "onboarding": {
             "class": "Onboarding",
             "methods": [
@@ -400,6 +417,10 @@
         "onboardingSessions": {
             "class": "OnboardingSessions",
             "methods": [
+                {
+                    "name": "bootstrap",
+                    "deprecated": false
+                },
                 {
                     "name": "create",
                     "deprecated": false
@@ -432,6 +453,10 @@
                 },
                 {
                     "name": "createBank",
+                    "deprecated": true
+                },
+                {
+                    "name": "createBankAccount",
                     "deprecated": false
                 },
                 {
@@ -676,7 +701,7 @@
             ]
         },
         "threeDsIntents": {
-            "class": "ThreeDS",
+            "class": "ThreeDsIntents",
             "methods": [
                 {
                     "name": "create",
@@ -751,7 +776,27 @@
             "class": "WebhookEndpoints",
             "methods": [
                 {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "delete",
+                    "deprecated": false
+                },
+                {
                     "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                },
+                {
+                    "name": "rotateSecret",
+                    "deprecated": false
+                },
+                {
+                    "name": "update",
                     "deprecated": false
                 }
             ]

--- a/tests/Endpoints/AccountsTest.php
+++ b/tests/Endpoints/AccountsTest.php
@@ -232,4 +232,25 @@ class AccountsTest extends TestCase
         $this->assertIsArray($result);
         $this->assertEquals('clear', $result['status']);
     }
+
+    public function testGetGeoCompliance()
+    {
+        $accountId = 'acct_test123';
+        $responseData = [
+            'status' => 'clear',
+            'sonar_session_id' => 'fps_123',
+            'evaluated_at' => '2024-01-01T00:00:00Z',
+        ];
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with("/v1/accounts/{$accountId}/geo_compliance")
+            ->andReturn($responseData);
+
+        $result = $this->accountsEndpoint->getGeoCompliance($accountId);
+
+        $this->assertIsArray($result);
+        $this->assertEquals('clear', $result['status']);
+    }
 }

--- a/tests/Endpoints/PaymentMethodsTest.php
+++ b/tests/Endpoints/PaymentMethodsTest.php
@@ -49,6 +49,23 @@ class PaymentMethodsTest extends TestCase
         $this->assertEquals($samplePaymentMethodData['id'], $paymentMethod->id);
     }
 
+    public function testCreateBankAccount()
+    {
+        $createRequest = new PaymentMethodCreateACHRequest(type: PaymentMethodType::ACH, customer: null, accountType: 'checking', accountNumber: 'XXXXXXXX', routingNumber: "XXXXXXXXX", billing: null);
+        $samplePaymentMethodData = $this->getSamplePaymentMethodData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/payment_methods', $createRequest->toArray())
+            ->andReturn($samplePaymentMethodData);
+
+        $paymentMethod = $this->paymentMethodsEndpoint->createBankAccount($createRequest);
+
+        $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
+        $this->assertEquals($samplePaymentMethodData['id'], $paymentMethod->id);
+    }
+
     public function testCreateCard()
     {
         $createRequest = new PaymentMethodCreateCardRequest(type: PaymentMethodType::CARD, customer: null, cardNumber: 'XXXXXXXX', expMonth: "XX", expYear: "XX", cvc: 'XXX', billing: null);


### PR DESCRIPTION
## Summary

**AI Generated, Developer to confirm:** *Converges frame-php onto the canonical SDK surface: adds `Accounts.getGeoCompliance` and `PaymentMethods.createBankAccount`, keeping the old `geoCompliance` / `createBank` as `@deprecated` delegators. Also fixes a surface-manifest generator bug where a deprecated backward-compat alias subclass overwrote its canonical class. Moves frame-php from 93.0% to 97.4% on the SDK parity audit.*

### Ticket Link

https://linear.app/framepayments/issue/FRA-5269

## Walkthrough Demo

TBD/Developer to provide

## Why the generator change

`bin/generate-surface-manifest.php` assigned `$resources[canonicalResource($short)]` unconditionally, so on a canonical-key collision the last class discovered won. `IdentityVerifications extends CustomerIdentityVerifications` (and `ThreeDS extends ThreeDsIntents`) both map to the same canonical key, and the deprecated alias was overwriting the canonical class — the actual source of the `customerIdentityVerifications` class-mismatches in the parity audit (not a code gap; the canonical class already exists). The generator now skips a `@deprecated` class when the key is already populated, so the canonical class wins regardless of discovery order.

## What's NOT in this PR

- `subscriptions.pause/resume` and `onboardingSessions.getByAccount` — the identical 3-item residual now shared by all three SDKs; pending a build-vs-de-annotate decision.
- Version tag bump — php ships on git tag at release time.

## Test coverage

- 2 new PHPUnit tests (Mockery): `testGetGeoCompliance`, `testCreateBankAccount`, mirroring the existing `geoCompliance` / `createBank` tests.
- Suite: 135 tests, 232 assertions, 0 failures; php-cs-fixer clean (0 of 146 files).

## How to Test

1. `docker run --rm -v "$PWD":/app -w /app composer:2 sh -c 'composer install && vendor/bin/phpunit'` — 135 tests, 0 failures.
2. `php bin/generate-surface-manifest.php` — regenerates `surface-manifest.json`; confirm `accounts` has `getGeoCompliance` (+ `geoCompliance` deprecated), `paymentMethods` has `createBankAccount` (+ `createBank` deprecated), and `customerIdentityVerifications` now reports class `CustomerIdentityVerifications` (not `IdentityVerifications`).
3. From the frame monolith: `FRAME_PHP_MANIFEST=../frame-php/surface-manifest.json bundle exec rake sdk_parity:audit` — frame-php reports 97.4% (was 93.0%), class-mismatch column 0.
