### PR TITLE
feat: add subscriptions pause / resume [FRA-4467]

### DIFF
--- a/src/Endpoints/Subscriptions.php
+++ b/src/Endpoints/Subscriptions.php
@@ -56,4 +56,18 @@ final class Subscriptions
 
         return Subscription::fromArray($json);
     }
+
+    public function pause(string $id): Subscription
+    {
+        $json = Client::post(self::BASE_PATH . "/{$id}/pause", []);
+
+        return Subscription::fromArray($json);
+    }
+
+    public function resume(string $id): Subscription
+    {
+        $json = Client::post(self::BASE_PATH . "/{$id}/resume", []);
+
+        return Subscription::fromArray($json);
+    }
 }

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,6 +1,6 @@
 {
     "sdk": "frame-php",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "resources": {
         "accounts": {
             "class": "Accounts",
@@ -671,6 +671,14 @@
                 },
                 {
                     "name": "list",
+                    "deprecated": false
+                },
+                {
+                    "name": "pause",
+                    "deprecated": false
+                },
+                {
+                    "name": "resume",
                     "deprecated": false
                 },
                 {

--- a/tests/Endpoints/SubscriptionsTest.php
+++ b/tests/Endpoints/SubscriptionsTest.php
@@ -137,4 +137,34 @@ class SubscriptionsTest extends TestCase
         $subscription = $this->subscriptionsEndpoint->cancel($subscriptionId);
         $this->assertInstanceOf(Subscription::class, $subscription);
     }
+
+    public function testPause()
+    {
+        $subscriptionId = 'sub_123';
+        $sampleSubscriptionData = $this->getSampleSubscriptionData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/subscriptions/{$subscriptionId}/pause", [])
+            ->andReturn($sampleSubscriptionData);
+
+        $subscription = $this->subscriptionsEndpoint->pause($subscriptionId);
+        $this->assertInstanceOf(Subscription::class, $subscription);
+    }
+
+    public function testResume()
+    {
+        $subscriptionId = 'sub_123';
+        $sampleSubscriptionData = $this->getSampleSubscriptionData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/subscriptions/{$subscriptionId}/resume", [])
+            ->andReturn($sampleSubscriptionData);
+
+        $subscription = $this->subscriptionsEndpoint->resume($subscriptionId);
+        $this->assertInstanceOf(Subscription::class, $subscription);
+    }
 }


### PR DESCRIPTION
## Summary

**AI Generated, Developer to confirm:** *Adds `subscriptions.pause(id)` and `subscriptions.resume(id)` to frame-php, wrapping the existing public `POST /v1/subscriptions/{id}/pause` and `/resume` endpoints that had no SDK method. Mirrors the existing `cancel()` pattern. Takes frame-php to 100% canonical parity.*

### Ticket Link

https://linear.app/framepayments/issue/FRA-4467

## Walkthrough Demo

TBD/Developer to provide

## How to Test

1. `docker run --rm -v "$PWD":/app -w /app composer:2 sh -c 'composer install && vendor/bin/phpunit --filter Subscriptions'` — 8 tests pass (incl. pause/resume).
2. `php bin/generate-surface-manifest.php` — manifest lists `pause` / `resume` on subscriptions.
3. From the monolith: `FRAME_PHP_MANIFEST=../frame-php/surface-manifest.json bundle exec rake sdk_parity:audit` — frame-php reports 100%.