### PR TITLE
feat: add canonical createApplePay + createGooglePay constructors [FRA-4461]

### DIFF
--- a/src/Endpoints/PaymentMethods.php
+++ b/src/Endpoints/PaymentMethods.php
@@ -30,6 +30,26 @@ final class PaymentMethods
     }
 
     /**
+     * @param array<string, mixed> $params
+     */
+    public function createApplePay(array $params): PaymentMethod
+    {
+        $json = Client::post(self::BASE_PATH, $params);
+
+        return PaymentMethod::fromArray($json);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function createGooglePay(array $params): PaymentMethod
+    {
+        $json = Client::post(self::BASE_PATH, $params);
+
+        return PaymentMethod::fromArray($json);
+    }
+
+    /**
      * @deprecated Use {@see createBankAccount()} (canonical). Removed at v2.
      */
     public function createBank(PaymentMethodCreateACHRequest $params): PaymentMethod

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -452,6 +452,10 @@
                     "deprecated": false
                 },
                 {
+                    "name": "createApplePay",
+                    "deprecated": false
+                },
+                {
                     "name": "createBank",
                     "deprecated": true
                 },
@@ -461,6 +465,10 @@
                 },
                 {
                     "name": "createCard",
+                    "deprecated": false
+                },
+                {
+                    "name": "createGooglePay",
                     "deprecated": false
                 },
                 {

--- a/tests/Endpoints/PaymentMethodsTest.php
+++ b/tests/Endpoints/PaymentMethodsTest.php
@@ -83,6 +83,50 @@ class PaymentMethodsTest extends TestCase
         $this->assertEquals($samplePaymentMethodData['id'], $paymentMethod->id);
     }
 
+    public function testCreateApplePay()
+    {
+        $createParams = [
+            'type' => 'apple_pay',
+            'customer' => null,
+            'token' => 'tok_apple_XXXX',
+            'billing' => null,
+        ];
+        $samplePaymentMethodData = $this->getSamplePaymentMethodData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/payment_methods', $createParams)
+            ->andReturn($samplePaymentMethodData);
+
+        $paymentMethod = $this->paymentMethodsEndpoint->createApplePay($createParams);
+
+        $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
+        $this->assertEquals($samplePaymentMethodData['id'], $paymentMethod->id);
+    }
+
+    public function testCreateGooglePay()
+    {
+        $createParams = [
+            'type' => 'google_pay',
+            'customer' => null,
+            'token' => 'tok_google_XXXX',
+            'billing' => null,
+        ];
+        $samplePaymentMethodData = $this->getSamplePaymentMethodData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/payment_methods', $createParams)
+            ->andReturn($samplePaymentMethodData);
+
+        $paymentMethod = $this->paymentMethodsEndpoint->createGooglePay($createParams);
+
+        $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
+        $this->assertEquals($samplePaymentMethodData['id'], $paymentMethod->id);
+    }
+
     public function testUpdate()
     {
         $methodId = 'method_123';


### PR DESCRIPTION
frame-php already had `createCard` / `createBankAccount` (+ `@deprecated createBank`); this adds the two wallet constructors `createApplePay` + `createGooglePay` to complete the canonical set. Generic `array $params` (no Apple/Google Pay request classes exist; matches the typed-body-untyped pattern in the file).

Tests: 2 added, 15 pass; php-cs-fixer clean.

Related: frame-node + frame-ruby `ryan/pm-typed-constructors`, and the monolith 1→N annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)