### PR TITLE
test: Payouts endpoint coverage (FRA-4464)

### DIFF
--- a/tests/Endpoints/PayoutsTest.php
+++ b/tests/Endpoints/PayoutsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\Payouts;
+use Frame\Tests\TestCase;
+use Mockery;
+
+class PayoutsTest extends TestCase
+{
+    private Payouts $payoutsEndpoint;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->payoutsEndpoint = new Payouts();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testCreate()
+    {
+        $params = [
+            'amount' => 1000,
+            'currency' => 'usd',
+            'account' => 'acct_test123',
+            'payment_method' => 'pm_test123',
+        ];
+        $samplePayoutData = $this->getSamplePayoutData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/payouts', $params)
+            ->andReturn($samplePayoutData);
+
+        $payout = $this->payoutsEndpoint->create($params);
+
+        $this->assertIsArray($payout);
+        $this->assertEquals($samplePayoutData['id'], $payout['id']);
+        $this->assertEquals(1000, $payout['amount']);
+        $this->assertEquals('usd', $payout['currency']);
+    }
+
+    public function testCreatePassesParamsThrough()
+    {
+        $params = ['amount' => 5000, 'currency' => 'usd'];
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/payouts', $params)
+            ->andReturn(['id' => 'po_test456', 'amount' => 5000]);
+
+        $payout = $this->payoutsEndpoint->create($params);
+
+        $this->assertIsArray($payout);
+        $this->assertEquals('po_test456', $payout['id']);
+    }
+
+    private function getSamplePayoutData(): array
+    {
+        return [
+            'id' => 'po_test123',
+            'object' => 'payout',
+            'amount' => 1000,
+            'currency' => 'usd',
+            'status' => 'pending',
+            'account' => 'acct_test123',
+            'payment_method' => 'pm_test123',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

M2 Payouts (FRA-4464) — the php SDK **already ships the dedicated `payouts.create` op** (`POST /v1/payouts`, `src/Endpoints/Payouts.php`). The canonical decision keeps `payouts.create` as its own dedicated operation (not re-routed into transfers).

The substantive part of this ticket — un-deprecating `POST /v1/payouts` in openapi + `x-frame-sdk` — is a **MONOLITH task owned by Ryan and is NOT in this repo**. Nothing in that workstream belongs here.

This PR only adds the previously-missing test coverage and regenerates the surface manifest.

| Method | HTTP | Path |
|---|---|---|
| `create` | POST | `/v1/payouts` |

php exposes **only** `create` — no stray `retrieve` (the ruby-only extra `retrieve` noted in Linear does not exist in php).

### Changes
- **Add `tests/Endpoints/PayoutsTest.php`** — covers `Payouts::create` (Mockery `alias:` style, mirroring `AccountsTest`): asserts the request POSTs to `/v1/payouts` with the given params and returns the decoded array.
- Ran `composer surface-manifest` — no diff (`Payouts::create` was already in the surface).

## Testing
- `composer test` — 154 passing ✅
- php-cs-fixer — 0 fixes ✅
- phpstan — the new test is clean (the 2 remaining errors are pre-existing baseline issues in `Customer.php` / `Refund.php`, unrelated to this change).

## Notes
- No openapi/rswag/monolith changes, no `retrieve` added, no payouts→transfers re-routing, no semantic changes — test coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)