### PR TITLE
feat: Transfers.confirm + chargeIntents demotion (FRA-4462)

### DIFF
--- a/src/Endpoints/ChargeIntents.php
+++ b/src/Endpoints/ChargeIntents.php
@@ -14,6 +14,9 @@ final class ChargeIntents
 {
     private const BASE_PATH = '/v1/charge_intents';
 
+    /**
+     * @deprecated Use {@see \Frame\Endpoints\Transfers::create()} instead. Removed at v2.
+     */
     public function create(ChargeIntentCreateRequest $params): ChargeIntent
     {
         $json = Client::post(self::BASE_PATH, $params->toArray());
@@ -21,6 +24,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463).
+     */
     public function update(string $id, ChargeIntentUpdateRequest $params): ChargeIntent
     {
         $json = Client::update(self::BASE_PATH . "/{$id}", $params->toArray());
@@ -28,6 +34,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Use {@see \Frame\Endpoints\Transfers::retrieve()} instead. Removed at v2.
+     */
     public function retrieve(string $id): ChargeIntent
     {
         $json = Client::get(self::BASE_PATH . "/{$id}");
@@ -35,6 +44,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Use {@see \Frame\Endpoints\Transfers::list()} instead. Removed at v2.
+     */
     public function list(int $perPage = 10, int $page = 1): ChargeIntentListResponse
     {
         $json = Client::get(self::BASE_PATH, ['per_page' => $perPage, 'page' => $page]);
@@ -42,6 +54,9 @@ final class ChargeIntents
         return ChargeIntentListResponse::fromArray($json);
     }
 
+    /**
+     * @deprecated Use {@see \Frame\Endpoints\Transfers::confirm()} instead. Removed at v2.
+     */
     public function confirm(string $id): ChargeIntent
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/confirm", []);
@@ -49,6 +64,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463).
+     */
     public function capture(string $id): ChargeIntent
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/capture", []);
@@ -56,6 +74,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463).
+     */
     public function cancel(string $id): ChargeIntent
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/cancel", []);
@@ -63,6 +84,9 @@ final class ChargeIntents
         return ChargeIntent::fromArray($json);
     }
 
+    /**
+     * @deprecated Removed at v2. No canonical transfer equivalent yet (FRA-4463).
+     */
     public function voidRemaining(string $id): ChargeIntent
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/void_remaining", []);

--- a/src/Endpoints/Transfers.php
+++ b/src/Endpoints/Transfers.php
@@ -24,4 +24,9 @@ final class Transfers
     {
         return Client::post(self::BASE_PATH, $params);
     }
+
+    public function confirm(string $id): array
+    {
+        return Client::post(self::BASE_PATH . "/{$id}/confirm", []);
+    }
 }

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -171,35 +171,35 @@
             "methods": [
                 {
                     "name": "cancel",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "capture",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "confirm",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "create",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "list",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "retrieve",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "update",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "voidRemaining",
-                    "deprecated": false
+                    "deprecated": true
                 }
             ]
         },
@@ -807,6 +807,10 @@
         "transfers": {
             "class": "Transfers",
             "methods": [
+                {
+                    "name": "confirm",
+                    "deprecated": false
+                },
                 {
                     "name": "create",
                     "deprecated": false

--- a/tests/Endpoints/TransfersTest.php
+++ b/tests/Endpoints/TransfersTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\Transfers;
+use Frame\Tests\TestCase;
+use Mockery;
+
+class TransfersTest extends TestCase
+{
+    private Transfers $endpoint;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->endpoint = new Transfers();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function sampleTransfer(): array
+    {
+        return [
+            'id' => 'tr_123',
+            'object' => 'transfer',
+            'amount' => 2000,
+            'currency' => 'usd',
+            'status' => 'pending',
+        ];
+    }
+
+    public function testList()
+    {
+        $sampleListData = [
+            'data' => [$this->sampleTransfer()],
+            'meta' => ['total_count' => 1],
+        ];
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with('/v1/transfers', ['per_page' => 10, 'page' => 1])
+            ->andReturn($sampleListData);
+
+        $response = $this->endpoint->list();
+
+        $this->assertIsArray($response);
+        $this->assertCount(1, $response['data']);
+        $this->assertEquals('tr_123', $response['data'][0]['id']);
+    }
+
+    public function testRetrieve()
+    {
+        $transferId = 'tr_123';
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with("/v1/transfers/{$transferId}")
+            ->andReturn($this->sampleTransfer());
+
+        $response = $this->endpoint->retrieve($transferId);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('tr_123', $response['id']);
+    }
+
+    public function testCreate()
+    {
+        $params = ['amount' => 2000, 'currency' => 'usd'];
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/transfers', $params)
+            ->andReturn($this->sampleTransfer());
+
+        $response = $this->endpoint->create($params);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('tr_123', $response['id']);
+    }
+
+    public function testConfirm()
+    {
+        $transferId = 'tr_123';
+        $confirmed = $this->sampleTransfer();
+        $confirmed['status'] = 'confirmed';
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/transfers/{$transferId}/confirm", [])
+            ->andReturn($confirmed);
+
+        $response = $this->endpoint->confirm($transferId);
+
+        $this->assertIsArray($response);
+        $this->assertEquals('confirmed', $response['status']);
+    }
+}


### PR DESCRIPTION
## Summary

M2 **Transfers core + chargeIntents demotion** from [FRA-4462](https://linear.app/framepayments/issue/FRA-4462), part of the API Canonicalization (+ Parity) project.

Adds the canonical `Transfers::confirm` action and demotes `ChargeIntents` to `@deprecated` (docblocks only — additive, no behavior change).

### New method on `Transfers`

| Method | HTTP | Path | Returns |
|---|---|---|---|
| `confirm` | POST | `/v1/transfers/{id}/confirm` | `array` |

Matches the existing `list`/`retrieve`/`create` on `Transfers` (raw `array` in/out, static `Client`, empty body on the action POST).

### chargeIntents demotion (`@deprecated` docblocks)

| Method | Deprecation note |
|---|---|
| `create` | → `{@see Transfers::create()}`. Removed at v2. |
| `retrieve` | → `{@see Transfers::retrieve()}`. Removed at v2. |
| `list` | → `{@see Transfers::list()}`. Removed at v2. |
| `confirm` | → `{@see Transfers::confirm()}`. Removed at v2. |
| `update` | Removed at v2. No canonical transfer equivalent yet (FRA-4463). |
| `capture` | Removed at v2. No canonical transfer equivalent yet (FRA-4463). |
| `cancel` | Removed at v2. No canonical transfer equivalent yet (FRA-4463). |
| `voidRemaining` | Removed at v2. No canonical transfer equivalent yet (FRA-4463). |

**No re-routing.** Deprecated methods keep hitting `/v1/charge_intents` and returning their existing typed `ChargeIntent` models — forwarding to `Transfers` would change return types (typed models → arrays), a breaking change violating additive-only. All method bodies are unchanged; only docblocks were added.

### Also in this PR
- New `tests/Endpoints/TransfersTest.php` — `list`/`retrieve`/`create`/`confirm`.
- Regenerated `surface-manifest.json` (Transfers gains non-deprecated `confirm`; all 8 ChargeIntents methods flip to `deprecated: true`; no other resource changes).

## Testing
- `composer test` — 156 passing ✅
- `phpstan analyse src` (level 5) — 0 errors in changed files ✅ (2 pre-existing errors in unrelated `Customer.php` / `Refund.php` remain untouched; the repo has no phpstan config committed)

## Notes
- Additive only — nothing removed, no signatures or return types changed.
- `update`/`capture`/`cancel`/`voidRemaining` are deprecated but fully functional; their canonical transfer equivalents are deferred to FRA-4463.
- Out of scope / not touched here: openapi/rswag/monolith, `fraud_decline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)