### PR TITLE
feat: accounts.confirmKycPrefill + customers demotion (FRA-4459)

### DIFF
--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -71,6 +71,13 @@ final class Accounts
         return Account::fromArray($json);
     }
 
+    public function confirmKycPrefill(string $id): Account
+    {
+        $json = Client::post(self::BASE_PATH . "/{$id}/kyc_prefill/confirm", []);
+
+        return Account::fromArray($json);
+    }
+
     public function getPlaidLinkToken(string $id): array
     {
         return Client::get(self::BASE_PATH . "/{$id}/plaid_link_token");

--- a/src/Endpoints/Customers.php
+++ b/src/Endpoints/Customers.php
@@ -37,6 +37,9 @@ final class Customers
         return Customer::fromArray($json);
     }
 
+    /**
+     * @deprecated Use {@see \Frame\Endpoints\Accounts::disable()} instead. Removed at v2.
+     */
     public function delete(string $id): Customer
     {
         $json = Client::delete(self::BASE_PATH . "/{$id}");
@@ -58,6 +61,9 @@ final class Customers
         return CustomerListResponse::fromArray($json);
     }
 
+    /**
+     * @deprecated Future target: {@see \Frame\Endpoints\Accounts}::block() (pending a monolith route). Removed at v2.
+     */
     public function block(string $id): Customer
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/block");
@@ -65,6 +71,9 @@ final class Customers
         return Customer::fromArray($json);
     }
 
+    /**
+     * @deprecated Future target: {@see \Frame\Endpoints\Accounts}::unblock() (pending a monolith route). Removed at v2.
+     */
     public function unblock(string $id): Customer
     {
         $json = Client::post(self::BASE_PATH . "/{$id}/unblock");
@@ -72,6 +81,9 @@ final class Customers
         return Customer::fromArray($json);
     }
 
+    /**
+     * @deprecated Use PaymentMethods::list(['account_id' => ...]) instead (FRA-4461). Removed at v2.
+     */
     public function getPaymentMethods(string $id, int $perPage = 10, int $page = 1): PaymentMethodListResponse
     {
         $json = Client::get(self::BASE_PATH . "/{$id}/payment_methods", ['per_page' => $perPage, 'page' => $page]);

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -6,6 +6,10 @@
             "class": "Accounts",
             "methods": [
                 {
+                    "name": "confirmKycPrefill",
+                    "deprecated": false
+                },
+                {
                     "name": "create",
                     "deprecated": false
                 },
@@ -276,7 +280,7 @@
             "methods": [
                 {
                     "name": "block",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "create",
@@ -284,11 +288,11 @@
                 },
                 {
                     "name": "delete",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "getPaymentMethods",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "list",
@@ -304,7 +308,7 @@
                 },
                 {
                     "name": "unblock",
-                    "deprecated": false
+                    "deprecated": true
                 },
                 {
                     "name": "update",

--- a/tests/Endpoints/AccountsTest.php
+++ b/tests/Endpoints/AccountsTest.php
@@ -174,6 +174,23 @@ class AccountsTest extends TestCase
         $this->assertInstanceOf(Account::class, $account);
     }
 
+    public function testConfirmKycPrefill()
+    {
+        $accountId = 'acct_test123';
+        $sampleAccountData = $this->getSampleAccountData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with("/v1/accounts/{$accountId}/kyc_prefill/confirm", [])
+            ->andReturn($sampleAccountData);
+
+        $account = $this->accountsEndpoint->confirmKycPrefill($accountId);
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals($sampleAccountData['id'], $account->id);
+    }
+
     public function testGetPlaidLinkToken()
     {
         $accountId = 'acct_test123';


### PR DESCRIPTION
## Summary

M2 accounts-core work from [FRA-4459](https://linear.app/framepayments/issue/FRA-4459), part of the API Canonicalization (+ Parity) project. Two changes, both additive:

1. Adds the canonical **`Accounts::confirmKycPrefill`** method.
2. Demotes the customers resource toward accounts by annotating cross-resource methods with `@deprecated` docblocks — **functional only, no re-routing**.

| Method | HTTP | Path |
|---|---|---|
| `Accounts::confirmKycPrefill` | POST | `/v1/accounts/{id}/kyc_prefill/confirm` → `Account` |

Path verified against the monolith route (singular `resource(:kyc_prefill)` + `post(:confirm)`) — it is `/kyc_prefill/confirm`, not `/confirm_kyc_prefill`. Empty body (`Client::post($path, [])`).

### Customers demotion (@deprecated, still functional)

| Method | Deprecation target |
|---|---|
| `delete` | `Accounts::disable()` (keeps `DELETE /v1/customers/{id}`) |
| `getPaymentMethods` | `PaymentMethods::list(['account_id' => ...])` (FRA-4461) |
| `block` | future `Accounts::block()` — pending a monolith route |
| `unblock` | future `Accounts::unblock()` — pending a monolith route |

Only methods with clear cross-resource targets are annotated. `create`/`update`/`retrieve`/`list`/`search` are untouched (no unambiguous mapping). `getGeoCompliance`/`geoCompliance` were already correct — no change.

### Also in this PR
- New `AccountsTest::testConfirmKycPrefill` asserting `POST /v1/accounts/{id}/kyc_prefill/confirm` with an empty body. Existing `CustomersTest` cases already cover the deprecated methods, confirming they remain functional.
- Regenerated `surface-manifest.json` (adds `accounts.confirmKycPrefill`; flags `customers.delete/block/unblock/getPaymentMethods` as deprecated; no other resource changes).

## Testing
- `composer test` — 153 tests, 255 assertions, all passing ✅
- `phpstan` (level 0, src) — no errors ✅
- `php-cs-fixer` — 0 files to fix ✅

## Deferred
- **`Accounts::block` / `Accounts::unblock` NOT added.** Verified there is no public `POST /v1/accounts/{id}/block|unblock` route — block/unblock exist only on the customers resource. The customers methods are annotated to point at these future targets but nothing is re-routed until a monolith route lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)