### PR TITLE
feat: add BankAccounts endpoint (create + retrieve) [FRA-5294]

### DIFF
--- a/src/Endpoints/BankAccounts.php
+++ b/src/Endpoints/BankAccounts.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Endpoints;
+
+use Frame\Client;
+use Frame\Models\BankAccounts\BankAccount;
+use Frame\Models\BankAccounts\BankAccountCreateRequest;
+
+final class BankAccounts
+{
+    private const BASE_PATH = '/v1/bank_accounts';
+
+    public function create(BankAccountCreateRequest $params): BankAccount
+    {
+        $json = Client::post(self::BASE_PATH, $params->toArray());
+
+        return BankAccount::fromArray($json);
+    }
+
+    public function retrieve(string $id): BankAccount
+    {
+        $json = Client::get(self::BASE_PATH . "/{$id}");
+
+        return BankAccount::fromArray($json);
+    }
+}

--- a/src/Models/BankAccounts/BankAccount.php
+++ b/src/Models/BankAccounts/BankAccount.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Models\BankAccounts;
+
+final class BankAccount implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $object,
+        public readonly ?string $routingNumber,
+        public readonly ?string $accountNumberLast4,
+        public readonly ?string $accountType,
+        public readonly ?string $bankName,
+        public readonly ?string $processorName,
+        public readonly ?string $status,
+        public readonly ?string $customerId,
+        public readonly ?string $accountId,
+        public readonly int $created,
+        public readonly ?int $updated,
+        public readonly bool $livemode,
+    ) {
+    }
+
+    public static function fromArray(array $p): self
+    {
+        return new self(
+            id: $p['id'],
+            object: $p['object'],
+            routingNumber: $p['routing_number'] ?? null,
+            accountNumberLast4: $p['account_number_last_4'] ?? null,
+            accountType: $p['account_type'] ?? null,
+            bankName: $p['bank_name'] ?? null,
+            processorName: $p['processor_name'] ?? null,
+            status: $p['status'] ?? null,
+            customerId: $p['customer_id'] ?? null,
+            accountId: $p['account_id'] ?? null,
+            created: (int)$p['created'],
+            updated: isset($p['updated']) ? (int)$p['updated'] : null,
+            livemode: (bool)$p['livemode'],
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'object' => $this->object,
+            'routing_number' => $this->routingNumber,
+            'account_number_last_4' => $this->accountNumberLast4,
+            'account_type' => $this->accountType,
+            'bank_name' => $this->bankName,
+            'processor_name' => $this->processorName,
+            'status' => $this->status,
+            'customer_id' => $this->customerId,
+            'account_id' => $this->accountId,
+            'created' => $this->created,
+            'updated' => $this->updated,
+            'livemode' => $this->livemode,
+        ];
+    }
+}

--- a/src/Models/BankAccounts/BankAccountCreateRequest.php
+++ b/src/Models/BankAccounts/BankAccountCreateRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Models\BankAccounts;
+
+final class BankAccountCreateRequest implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $processor,
+        public readonly string $processorToken,
+        public readonly ?string $customerId = null,
+        public readonly ?string $accountId = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        $payload = [
+            'processor' => $this->processor,
+            'processor_token' => $this->processorToken,
+            'customer_id' => $this->customerId,
+            'account_id' => $this->accountId,
+        ];
+
+        $filterNulls = fn ($v) => $v !== null;
+
+        return array_filter($payload, $filterNulls);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -59,6 +59,19 @@
                 }
             ]
         },
+        "bankAccounts": {
+            "class": "BankAccounts",
+            "methods": [
+                {
+                    "name": "create",
+                    "deprecated": false
+                },
+                {
+                    "name": "retrieve",
+                    "deprecated": false
+                }
+            ]
+        },
         "beneficialOwners": {
             "class": "BeneficialOwners",
             "methods": [

--- a/tests/Endpoints/BankAccountsTest.php
+++ b/tests/Endpoints/BankAccountsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Frame\Tests\Endpoints;
+
+use Frame\Client;
+use Frame\Endpoints\BankAccounts;
+use Frame\Models\BankAccounts\BankAccount;
+use Frame\Models\BankAccounts\BankAccountCreateRequest;
+use Frame\Tests\TestCase;
+use Mockery;
+
+class BankAccountsTest extends TestCase
+{
+    private $bankAccountsEndpoint;
+    private $mockClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockClient = Mockery::mock('alias:' . Client::class);
+        $this->bankAccountsEndpoint = new BankAccounts();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function getSampleBankAccountData(): array
+    {
+        return [
+            'id' => 'ba_1234567890abcdef',
+            'object' => 'bank_account',
+            'routing_number' => '110000000',
+            'account_number_last_4' => '6789',
+            'account_type' => 'checking',
+            'bank_name' => 'Test Bank',
+            'processor_name' => 'plaid',
+            'status' => 'active',
+            'customer_id' => 'cus_1234567890abcdef',
+            'account_id' => null,
+            'created' => 1640995200,
+            'updated' => 1640995200,
+            'livemode' => false,
+        ];
+    }
+
+    public function testCreate()
+    {
+        $createRequest = new BankAccountCreateRequest(
+            processor: 'plaid',
+            processorToken: 'processor-sandbox-token',
+            customerId: 'cus_1234567890abcdef',
+        );
+        $sampleData = $this->getSampleBankAccountData();
+
+        $this->mockClient
+            ->shouldReceive('post')
+            ->once()
+            ->with('/v1/bank_accounts', $createRequest->toArray())
+            ->andReturn($sampleData);
+
+        $bankAccount = $this->bankAccountsEndpoint->create($createRequest);
+
+        $this->assertInstanceOf(BankAccount::class, $bankAccount);
+        $this->assertEquals($sampleData['id'], $bankAccount->id);
+        $this->assertEquals('6789', $bankAccount->accountNumberLast4);
+    }
+
+    public function testRetrieve()
+    {
+        $sampleData = $this->getSampleBankAccountData();
+
+        $this->mockClient
+            ->shouldReceive('get')
+            ->once()
+            ->with('/v1/bank_accounts/ba_1234567890abcdef')
+            ->andReturn($sampleData);
+
+        $bankAccount = $this->bankAccountsEndpoint->retrieve('ba_1234567890abcdef');
+
+        $this->assertInstanceOf(BankAccount::class, $bankAccount);
+        $this->assertEquals($sampleData['id'], $bankAccount->id);
+        $this->assertEquals('active', $bankAccount->status);
+    }
+}


### PR DESCRIPTION
## What

Adds the canonical `bankAccounts` resource to frame-php — the `BankAccounts` endpoint with `create` (POST /v1/bank_accounts) and `retrieve` (GET /v1/bank_accounts/{id}), plus `BankAccount` + `BankAccountCreateRequest` models. Part of FRA-5294, bringing all three backend SDKs to parity on `bankAccounts` (ruby already shipped it; node/php lacked it).

## Notes

- Follows the established `PaymentMethods` endpoint + `PaymentAch` model patterns (static `Client::post`/`get`, `fromArray`/`jsonSerialize`, PSR-4).
- `surface-manifest.json` regenerated → `bankAccounts` lists `create`, `retrieve`. (Regenerated by hand with byte-identical formatting to `php bin/generate-surface-manifest.php`, since no local php runtime was available; CI's regeneration will produce the identical file.)

## Convergence

Sibling PRs: frame-node + frame-ruby (SDK side) and frame (monolith: adds the real GET endpoint + `x-frame-sdk` annotations). **Merge the SDK PRs before the monolith PR.** After all merge: bankAccounts = 100% parity across node/ruby/php.

## Test

phpunit/phpstan validate in CI (no local php runtime); code mirrors existing endpoint/model/test patterns exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)