### PR TITLE
feat: add Subscriptions cancelScheduledChange [FRA-5441]

### DIFF
--- a/src/Endpoints/Subscriptions.php
+++ b/src/Endpoints/Subscriptions.php
@@ -70,4 +70,11 @@ final class Subscriptions
 
         return Subscription::fromArray($json);
     }
+
+    public function cancelScheduledChange(string $id): Subscription
+    {
+        $json = Client::delete(self::BASE_PATH . "/{$id}/scheduled_change");
+
+        return Subscription::fromArray($json);
+    }
 }

--- a/src/Models/Subscriptions/Subscription.php
+++ b/src/Models/Subscriptions/Subscription.php
@@ -32,6 +32,7 @@ final class Subscription implements \JsonSerializable
         public readonly int $startDate,
         public readonly int $created,
         public readonly string $object,
+        public readonly ?SubscriptionScheduledChange $scheduledChange,
     ) {
     }
 
@@ -73,6 +74,9 @@ final class Subscription implements \JsonSerializable
             startDate: (int)$p['start_date'],
             created: (int)$p['created'],
             object: $p['object'],
+            scheduledChange: isset($p['scheduled_change']) && is_array($p['scheduled_change'])
+                ? SubscriptionScheduledChange::fromArray($p['scheduled_change'])
+                : null,
         );
     }
 
@@ -102,6 +106,7 @@ final class Subscription implements \JsonSerializable
             'created' => $this->created,
             'object' => $this->object,
             'plan' => $this->plan,
+            'scheduled_change' => $this->scheduledChange,
         ];
     }
 }

--- a/src/Models/Subscriptions/SubscriptionScheduledChange.php
+++ b/src/Models/Subscriptions/SubscriptionScheduledChange.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frame\Models\Subscriptions;
+
+final class SubscriptionScheduledChange implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $object,
+        public readonly string $product,
+        public readonly bool $intervalSwitch,
+        public readonly int $effectiveDate,
+        public readonly int $created
+    ) {
+    }
+
+    public static function fromArray(array $p): self
+    {
+        return new self(
+            id: $p['id'],
+            object: $p['object'],
+            product: $p['product'],
+            intervalSwitch: (bool)$p['interval_switch'],
+            effectiveDate: (int)$p['effective_date'],
+            created: (int)$p['created']
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'object' => $this->object,
+            'product' => $this->product,
+            'interval_switch' => $this->intervalSwitch,
+            'effective_date' => $this->effectiveDate,
+            'created' => $this->created,
+        ];
+    }
+}

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,6 +1,6 @@
 {
     "sdk": "frame-php",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "resources": {
         "accounts": {
             "class": "Accounts",

--- a/surface-manifest.json
+++ b/surface-manifest.json
@@ -1,6 +1,6 @@
 {
     "sdk": "frame-php",
-    "version": "1.0.11",
+    "version": "1.1.0",
     "resources": {
         "accounts": {
             "class": "Accounts",
@@ -721,6 +721,10 @@
             "methods": [
                 {
                     "name": "cancel",
+                    "deprecated": false
+                },
+                {
+                    "name": "cancelScheduledChange",
                     "deprecated": false
                 },
                 {

--- a/tests/Endpoints/SubscriptionsTest.php
+++ b/tests/Endpoints/SubscriptionsTest.php
@@ -7,6 +7,7 @@ use Frame\Endpoints\Subscriptions;
 use Frame\Models\Subscriptions\Subscription;
 use Frame\Models\Subscriptions\SubscriptionCreateRequest;
 use Frame\Models\Subscriptions\SubscriptionListResponse;
+use Frame\Models\Subscriptions\SubscriptionScheduledChange;
 use Frame\Models\Subscriptions\SubscriptionSearchRequest;
 use Frame\Models\Subscriptions\SubscriptionStatus;
 use Frame\Models\Subscriptions\SubscriptionUpdateRequest;
@@ -166,5 +167,37 @@ class SubscriptionsTest extends TestCase
 
         $subscription = $this->subscriptionsEndpoint->resume($subscriptionId);
         $this->assertInstanceOf(Subscription::class, $subscription);
+    }
+
+    public function testCancelScheduledChange()
+    {
+        $subscriptionId = 'sub_123';
+        $sampleSubscriptionData = $this->getSampleSubscriptionData();
+
+        $this->mockClient
+            ->shouldReceive('delete')
+            ->once()
+            ->with("/v1/subscriptions/{$subscriptionId}/scheduled_change")
+            ->andReturn($sampleSubscriptionData);
+
+        $subscription = $this->subscriptionsEndpoint->cancelScheduledChange($subscriptionId);
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertNull($subscription->scheduledChange);
+    }
+
+    public function testSubscriptionHydratesScheduledChange()
+    {
+        $sampleSubscriptionData = $this->getSampleSubscriptionData();
+        $sampleSubscriptionData['scheduled_change'] = $this->getSampleScheduledChangeData();
+
+        $subscription = Subscription::fromArray($sampleSubscriptionData);
+
+        $this->assertInstanceOf(SubscriptionScheduledChange::class, $subscription->scheduledChange);
+        $this->assertEquals('ssc_123', $subscription->scheduledChange->id);
+        $this->assertEquals('subscription_scheduled_change', $subscription->scheduledChange->object);
+        $this->assertEquals('prod_123', $subscription->scheduledChange->product);
+        $this->assertTrue($subscription->scheduledChange->intervalSwitch);
+        $this->assertEquals(1640995200, $subscription->scheduledChange->effectiveDate);
+        $this->assertEquals(1640995200, $subscription->scheduledChange->created);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -331,6 +331,21 @@ abstract class TestCase extends PHPUnitTestCase
     }
 
     /**
+     * Helper method to get a sample subscription scheduled change data array
+     */
+    protected function getSampleScheduledChangeData(): array
+    {
+        return [
+            'id' => 'ssc_123',
+            'object' => 'subscription_scheduled_change',
+            'product' => 'prod_123',
+            'interval_switch' => true,
+            'effective_date' => 1640995200,
+            'created' => 1640995200,
+        ];
+    }
+
+    /**
      * Helper method to get a sample account data array
      */
     protected function getSampleAccountData(): array


### PR DESCRIPTION
## Ticket

[FRA-5441](https://linear.app/framepayments/issue/FRA-5441/sdk-parity-build-subscriptionscancelscheduledchange-across-frame)

## What

Adds the canonical `(new Subscriptions())->cancelScheduledChange($id)` method: `DELETE /v1/subscriptions/{id}/scheduled_change`, returning the `Subscription` model with `scheduledChange` `null`. Mirrors the sibling action methods (`cancel`/`pause`/`resume`) exactly. The API returns 404 when the subscription doesn't exist **or** no change is pending; errors surface through the shared `Client` handling like every other method.

Also adds the previously missing scheduled-change surface to the model layer: new `SubscriptionScheduledChange` response model (`id`, `object`, `product`, `intervalSwitch`, `effectiveDate`, `created`, matching the public OpenAPI schema) built on the same readonly-ctor + `fromArray` + snake_case `jsonSerialize` pattern as `SubscriptionPlan`, and a `?SubscriptionScheduledChange $scheduledChange` property on `Subscription` hydrated via the same `isset()/is_array()` pattern as `plan`. `surface-manifest.json` regenerated via `php bin/generate-surface-manifest.php`.

Canonical name confirmed against the registry (`frame-docs/lib/sdk-docs-standards/CROSS_SDK_NAMING.md`). Closes the parity gap recorded by FRA-5404 / Frame-Payments/frame#3946, which documented the endpoint but left it un-annotated pending this method.

## How to Test

- `./vendor/bin/phpunit` (PHP 8.3) → OK, 163 tests, 285 assertions (2 new: DELETE hits the right path with `scheduledChange` null; a populated payload hydrates the nested model, all 6 fields)
- `php-cs-fixer` → 0 fixable; `phpstan` level 5 on changed files → no errors
- From a monolith checkout with sibling SDK clones: `bundle exec rake sdk_parity:audit` → frame-php 100% (138/138), 0 missing

## Notes

- **Constructor default (deliberate):** `$scheduledChange` has **no** `= null` default, matching all 8 existing nullable response fields — these DTOs are hydrated exclusively via `fromArray`, and past field additions followed the same convention. If you treat direct response-model construction as a supported consumer surface, say the word and I'll add the default.
- The manifest's `"version": "1.0.11" → "1.1.0"` is the generator's faithful output (it derives from `git describe --tags`; tag `v1.1.0` already existed but the committed manifest was stale) — not a hand-bump.
- The monolith PR annotating `cancelSubscriptionScheduledChange` with `x-frame-sdk` should merge **after** this one (no phantom annotations, per SDK_PARITY_POLICY).
